### PR TITLE
create an image url cache + get image to display on VenueDetailVC

### DIFF
--- a/VenueFinder/Services/FoursquareService.swift
+++ b/VenueFinder/Services/FoursquareService.swift
@@ -22,6 +22,8 @@ class FoursquareService {
         return dateFormatter.string(from: date)
     }()
     
+    var imageUrlCache: [String: URL] = [:]
+    
     public func fetchVenues(atLatitude lat: Double,
                           atLongitude long: Double,
                           forQuery query: String,
@@ -66,7 +68,7 @@ class FoursquareService {
         let queryParams: [String: String] = [
             "near": "\(near)",
             "query": "\(query)",
-            "limit": "2",
+            "limit": "1",
             "client_id": "\(FOURSQUARE_CLIENT_ID)",
             "client_secret": "\(FOURSQUARE_CLIENT_SECRET)",
             "v": "\(versionDate)"

--- a/VenueFinder/View Controllers/VenueDetailVC.swift
+++ b/VenueFinder/View Controllers/VenueDetailVC.swift
@@ -19,7 +19,7 @@ class VenueDetailVC: UIViewController {
         }
     }
     
-    private var venuePhoto: VenuePhoto?
+    //private var venuePhoto: VenuePhoto?
     
     let venueDetailImage = UIImageView()
     let venueDetailContainer = VenueDetailContainerView()
@@ -43,6 +43,8 @@ class VenueDetailVC: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = Styler.Color.darkBlue
         venueDetailImage.backgroundColor = .lightGray
+        venueDetailImage.contentMode = .scaleAspectFill
+        venueDetailImage.clipsToBounds = true
         
         navigationController?.navigationBar.tintColor = .white
         navigationController?.navigationBar.barStyle = .black
@@ -173,6 +175,12 @@ class VenueDetailVC: UIViewController {
         
         if let venue = venue {
             navigationItem.title = venue.name
+            if let photoUrl = FoursquareService.shared.imageUrlCache[venue.id] {
+                venueDetailImage.sd_setImage(with: photoUrl)
+            } else {
+                venueDetailImage.image = UIImage(named: "nosign")?.withTintColor(.white, renderingMode: .alwaysOriginal)
+            }
+            
             
             if let address = venue.location.address, let city = venue.location.city, let state = venue.location.state, let zipcode = venue.location.postalCode {
                 venueDetailContainer.venueStreetAddressBody.text = address

--- a/VenueFinder/Views/VenueTableViewCell.swift
+++ b/VenueFinder/Views/VenueTableViewCell.swift
@@ -128,6 +128,9 @@ class VenueTableViewCell: UITableViewCell {
         if let venuePhoto = venuePhoto, let venuePhotoItems = venuePhoto.items, let venuePhotoInfo = venuePhotoItems.first {
             guard let url = URL(string: "\(venuePhotoInfo.prefix)\(venuePhotoInfo.width)x\(venuePhotoInfo.height)\(venuePhotoInfo.suffix)") else { return }
             venueImageView.sd_setImage(with: url)
+            if let venue = venue {
+                FoursquareService.shared.imageUrlCache[venue.id] = url
+            }
         } else {
             DispatchQueue.main.async {
                 self.venueImageView.image = UIImage(named: "nosign")?.withTintColor(.white, renderingMode: .alwaysOriginal)


### PR DESCRIPTION
create a shared image url cache that adds a venues photos to the cache keyed by venue ID, allowing for an easy image url lookup when user loads VenueDetailVC without having to make another networking call. 